### PR TITLE
Fixes for Reforger 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.rdb
-Language/*.conf*
+*.json
+meta
+preview*.jpg

--- a/Language/CEN_CarrierSystem_localization.cs_cz.conf
+++ b/Language/CEN_CarrierSystem_localization.cs_cz.conf
@@ -1,0 +1,16 @@
+StringTableRuntime {
+ Ids {
+  "CEN_CarrierSystem-AddonName"
+  "CEN_CarrierSystem-UserAction_AddCasualty"
+  "CEN_CarrierSystem-UserAction_Carry"
+  "CEN_CarrierSystem-UserAction_Carrying"
+  "CEN_CarrierSystem-UserAction_Release"
+ }
+ Texts {
+  "CEN - Carrier System"
+  "Add Casualty"
+  "Carry"
+  "Carrying"
+  "Release"
+ }
+}

--- a/Language/CEN_CarrierSystem_localization.de_de.conf
+++ b/Language/CEN_CarrierSystem_localization.de_de.conf
@@ -1,0 +1,16 @@
+StringTableRuntime {
+ Ids {
+  "CEN_CarrierSystem-AddonName"
+  "CEN_CarrierSystem-UserAction_AddCasualty"
+  "CEN_CarrierSystem-UserAction_Carry"
+  "CEN_CarrierSystem-UserAction_Carrying"
+  "CEN_CarrierSystem-UserAction_Release"
+ }
+ Texts {
+  "CEN - Carrier System"
+  "Add Casualty"
+  "Tragen"
+  "Am Tragen"
+  "Ablegen"
+ }
+}

--- a/Language/CEN_CarrierSystem_localization.en_us.conf
+++ b/Language/CEN_CarrierSystem_localization.en_us.conf
@@ -1,0 +1,16 @@
+StringTableRuntime {
+ Ids {
+  "CEN_CarrierSystem-AddonName"
+  "CEN_CarrierSystem-UserAction_AddCasualty"
+  "CEN_CarrierSystem-UserAction_Carry"
+  "CEN_CarrierSystem-UserAction_Carrying"
+  "CEN_CarrierSystem-UserAction_Release"
+ }
+ Texts {
+  "CEN - Carrier System"
+  "Add Casualty"
+  "Carry"
+  "Carrying"
+  "Release"
+ }
+}

--- a/Language/CEN_CarrierSystem_localization.es_es.conf
+++ b/Language/CEN_CarrierSystem_localization.es_es.conf
@@ -1,0 +1,16 @@
+StringTableRuntime {
+ Ids {
+  "CEN_CarrierSystem-AddonName"
+  "CEN_CarrierSystem-UserAction_AddCasualty"
+  "CEN_CarrierSystem-UserAction_Carry"
+  "CEN_CarrierSystem-UserAction_Carrying"
+  "CEN_CarrierSystem-UserAction_Release"
+ }
+ Texts {
+  "CEN - Carrier System"
+  "Add Casualty"
+  "Carry"
+  "Carrying"
+  "Release"
+ }
+}

--- a/Language/CEN_CarrierSystem_localization.fr_fr.conf
+++ b/Language/CEN_CarrierSystem_localization.fr_fr.conf
@@ -1,0 +1,16 @@
+StringTableRuntime {
+ Ids {
+  "CEN_CarrierSystem-AddonName"
+  "CEN_CarrierSystem-UserAction_AddCasualty"
+  "CEN_CarrierSystem-UserAction_Carry"
+  "CEN_CarrierSystem-UserAction_Carrying"
+  "CEN_CarrierSystem-UserAction_Release"
+ }
+ Texts {
+  "CEN - Carrier System"
+  "Add Casualty"
+  "Porter"
+  "Porter"
+  "Déposer"
+ }
+}

--- a/Language/CEN_CarrierSystem_localization.it_it.conf
+++ b/Language/CEN_CarrierSystem_localization.it_it.conf
@@ -1,0 +1,16 @@
+StringTableRuntime {
+ Ids {
+  "CEN_CarrierSystem-AddonName"
+  "CEN_CarrierSystem-UserAction_AddCasualty"
+  "CEN_CarrierSystem-UserAction_Carry"
+  "CEN_CarrierSystem-UserAction_Carrying"
+  "CEN_CarrierSystem-UserAction_Release"
+ }
+ Texts {
+  "CEN - Carrier System"
+  "Add Casualty"
+  "Carry"
+  "Carrying"
+  "Release"
+ }
+}

--- a/Language/CEN_CarrierSystem_localization.ja_jp.conf
+++ b/Language/CEN_CarrierSystem_localization.ja_jp.conf
@@ -1,0 +1,16 @@
+StringTableRuntime {
+ Ids {
+  "CEN_CarrierSystem-AddonName"
+  "CEN_CarrierSystem-UserAction_AddCasualty"
+  "CEN_CarrierSystem-UserAction_Carry"
+  "CEN_CarrierSystem-UserAction_Carrying"
+  "CEN_CarrierSystem-UserAction_Release"
+ }
+ Texts {
+  "CEN - Carrier System"
+  "Add Casualty"
+  "Carry"
+  "Carrying"
+  "Release"
+ }
+}

--- a/Language/CEN_CarrierSystem_localization.ko_kr.conf
+++ b/Language/CEN_CarrierSystem_localization.ko_kr.conf
@@ -1,0 +1,16 @@
+StringTableRuntime {
+ Ids {
+  "CEN_CarrierSystem-AddonName"
+  "CEN_CarrierSystem-UserAction_AddCasualty"
+  "CEN_CarrierSystem-UserAction_Carry"
+  "CEN_CarrierSystem-UserAction_Carrying"
+  "CEN_CarrierSystem-UserAction_Release"
+ }
+ Texts {
+  "CEN - Carrier System"
+  "Add Casualty"
+  "Carry"
+  "Carrying"
+  "Release"
+ }
+}

--- a/Language/CEN_CarrierSystem_localization.pl_pl.conf
+++ b/Language/CEN_CarrierSystem_localization.pl_pl.conf
@@ -1,0 +1,16 @@
+StringTableRuntime {
+ Ids {
+  "CEN_CarrierSystem-AddonName"
+  "CEN_CarrierSystem-UserAction_AddCasualty"
+  "CEN_CarrierSystem-UserAction_Carry"
+  "CEN_CarrierSystem-UserAction_Carrying"
+  "CEN_CarrierSystem-UserAction_Release"
+ }
+ Texts {
+  "CEN - Carrier System"
+  "Add Casualty"
+  "Carry"
+  "Carrying"
+  "Release"
+ }
+}

--- a/Language/CEN_CarrierSystem_localization.pt_br.conf
+++ b/Language/CEN_CarrierSystem_localization.pt_br.conf
@@ -1,0 +1,16 @@
+StringTableRuntime {
+ Ids {
+  "CEN_CarrierSystem-AddonName"
+  "CEN_CarrierSystem-UserAction_AddCasualty"
+  "CEN_CarrierSystem-UserAction_Carry"
+  "CEN_CarrierSystem-UserAction_Carrying"
+  "CEN_CarrierSystem-UserAction_Release"
+ }
+ Texts {
+  "CEN - Carrier System"
+  "Add Casualty"
+  "Carry"
+  "Carrying"
+  "Release"
+ }
+}

--- a/Language/CEN_CarrierSystem_localization.ru_ru.conf
+++ b/Language/CEN_CarrierSystem_localization.ru_ru.conf
@@ -1,0 +1,16 @@
+StringTableRuntime {
+ Ids {
+  "CEN_CarrierSystem-AddonName"
+  "CEN_CarrierSystem-UserAction_AddCasualty"
+  "CEN_CarrierSystem-UserAction_Carry"
+  "CEN_CarrierSystem-UserAction_Carrying"
+  "CEN_CarrierSystem-UserAction_Release"
+ }
+ Texts {
+  "CEN - Carrier System"
+  "Add Casualty"
+  "Carry"
+  "Carrying"
+  "Release"
+ }
+}

--- a/Language/CEN_CarrierSystem_localization.zh_cn.conf
+++ b/Language/CEN_CarrierSystem_localization.zh_cn.conf
@@ -1,0 +1,16 @@
+StringTableRuntime {
+ Ids {
+  "CEN_CarrierSystem-AddonName"
+  "CEN_CarrierSystem-UserAction_AddCasualty"
+  "CEN_CarrierSystem-UserAction_Carry"
+  "CEN_CarrierSystem-UserAction_Carrying"
+  "CEN_CarrierSystem-UserAction_Release"
+ }
+ Texts {
+  "CEN - Carrier System"
+  "Add Casualty"
+  "Carry"
+  "Carrying"
+  "Release"
+ }
+}

--- a/Prefabs/Characters/Core/Character_Base.et
+++ b/Prefabs/Characters/Core/Character_Base.et
@@ -5,7 +5,7 @@ SCR_ChimeraCharacter {
    additionalActions {
     CEN_CarrierSystem_CarryUserAction "{5DDEFB529A8EBB97}" {
      ParentContextList {
-      "Chest"
+      "LowerTorso"
      }
      UIInfo UIInfo "{5DDEFB52A5D867D8}" {
       Name "#CEN_CarrierSystem-UserAction_Carry"

--- a/Prefabs/Helpers/CEN_CarrierSystem_Helper.et
+++ b/Prefabs/Helpers/CEN_CarrierSystem_Helper.et
@@ -10,7 +10,14 @@ CEN_CarrierSystem_Helper : "{278E487E19D82680}Prefabs/Vehicles/Core/Vehicle_Carg
      PassengerPositionInfo EntitySlotInfo s1 {
       Offset -0.1 -0.6 0.05
      }
+     ForcedFreeLook 1
      SeatType 1
+     DoorInfoList {
+      CompartmentDoorInfo "{5ED710990552D132}" {
+       EntryPositionInfo PointInfo "{5ED71099005CE831}" {
+       }
+      }
+     }
      CanOccupantEquipGadget 0
     }
    }

--- a/Scripts/Game/CEN_CarrierSystem/Character/SCR_CharacterControllerComponent.c
+++ b/Scripts/Game/CEN_CarrierSystem/Character/SCR_CharacterControllerComponent.c
@@ -1,5 +1,8 @@
+//------------------------------------------------------------------------------------------------
 modded class SCR_CharacterControllerComponent : CharacterControllerComponent
 {
+	//------------------------------------------------------------------------------------------------
+	//! Release carried player if the carrier falls unconscious
 	override protected void OnConsciousnessChanged(bool conscious)
 	{
 		super.OnConsciousnessChanged(conscious);

--- a/Scripts/Game/CEN_CarrierSystem/Entities/CEN_CarrierSystem_Helper.c
+++ b/Scripts/Game/CEN_CarrierSystem/Entities/CEN_CarrierSystem_Helper.c
@@ -133,10 +133,14 @@ class CEN_CarrierSystem_Helper : GenericEntity
 		{
 			GetGame().GetCallqueue().CallLater(CleanUp, CLEANUP_TIMEOUT, false);
 			return;
-		}
+		};
 		
-		RplId carriedId = RplComponent.Cast(m_eCarried.FindComponent(RplComponent)).Id();
+		RplComponent carriedRpl =  RplComponent.Cast(m_eCarried.FindComponent(RplComponent));
+		RplId carriedId = carriedRpl.Id();
 		Rpc(RpcDo_Owner_CleanUp, carriedId);
+		vector carrierTransform[4];
+		m_eCarrier.GetWorldTransform(carrierTransform);
+		carriedRpl.ForceNodeMovement(carrierTransform);
 		SCR_EntityHelper.DeleteEntityAndChildren(this);
 	}
 	

--- a/Scripts/Game/CEN_CarrierSystem/Entities/CEN_CarrierSystem_Helper.c
+++ b/Scripts/Game/CEN_CarrierSystem/Entities/CEN_CarrierSystem_Helper.c
@@ -205,7 +205,10 @@ class CEN_CarrierSystem_Helper : GenericEntity
 	//! Get the instance of the helper compartment entity for the given carrier
 	protected static CEN_CarrierSystem_Helper GetHelperFromCarrier(IEntity carrier)
 	{
-		CEN_CarrierSystem_Helper helper = null;
+		if (!carrier)
+			return null;
+		
+		CEN_CarrierSystem_Helper helper;
 		IEntity child = carrier.GetChildren();
 		
 		while (child)
@@ -228,6 +231,9 @@ class CEN_CarrierSystem_Helper : GenericEntity
 	//! Get the instance of the helper compartment entity for the given carried player
 	protected static CEN_CarrierSystem_Helper GetHelperFromCarried(IEntity carried)
 	{
+		if (!carried)
+			return null;
+		
 		CEN_CarrierSystem_Helper helper = CEN_CarrierSystem_Helper.Cast(carried.GetParent());
 		
 		if (!helper || helper.m_bMarkedForDeletion)

--- a/Scripts/Game/CEN_CarrierSystem/GameMode/SCR_BaseGameMode.c
+++ b/Scripts/Game/CEN_CarrierSystem/GameMode/SCR_BaseGameMode.c
@@ -1,5 +1,8 @@
+//------------------------------------------------------------------------------------------------
 modded class SCR_BaseGameMode : BaseGameMode
 {
+	//------------------------------------------------------------------------------------------------
+	//! Release carried player if they are killed or the carrier is killed
 	protected override void OnPlayerKilled(int playerId, IEntity playerEntity, IEntity killerEntity, notnull Instigator killer)
 	{
 		CEN_CarrierSystem_Helper.ReleaseFromCarrier(playerEntity);
@@ -7,6 +10,8 @@ modded class SCR_BaseGameMode : BaseGameMode
 		super.OnPlayerKilled(playerId, playerEntity, killerEntity, killer);
 	};
 	
+	//------------------------------------------------------------------------------------------------
+	//! Release carried player if they disconnected or the carrier disconnected
 	protected override void OnPlayerDisconnected(int playerId, KickCauseCode cause, int timeout)
 	{
 		IEntity player = GetGame().GetPlayerManager().GetPlayerControlledEntity(playerId);

--- a/Scripts/Game/CEN_CarrierSystem/GameMode/SCR_BaseGameMode.c
+++ b/Scripts/Game/CEN_CarrierSystem/GameMode/SCR_BaseGameMode.c
@@ -1,10 +1,10 @@
 modded class SCR_BaseGameMode : BaseGameMode
 {
-	protected override void OnPlayerKilled(int playerId, IEntity player, IEntity killer)
+	protected override void OnPlayerKilled(int playerId, IEntity playerEntity, IEntity killerEntity, notnull Instigator killer)
 	{
-		CEN_CarrierSystem_Helper.ReleaseFromCarrier(player);
-		CEN_CarrierSystem_Helper.ReleaseCarried(player);
-		super.OnPlayerKilled(playerId, player, killer);
+		CEN_CarrierSystem_Helper.ReleaseFromCarrier(playerEntity);
+		CEN_CarrierSystem_Helper.ReleaseCarried(playerEntity);
+		super.OnPlayerKilled(playerId, playerEntity, killerEntity, killer);
 	};
 	
 	protected override void OnPlayerDisconnected(int playerId, KickCauseCode cause, int timeout)

--- a/Scripts/Game/CEN_CarrierSystem/UI/HUD/AvailableActions/Conditions/CEN_CarrierSystem_IsCharacterCarrierCondition.c
+++ b/Scripts/Game/CEN_CarrierSystem/UI/HUD/AvailableActions/Conditions/CEN_CarrierSystem_IsCharacterCarrierCondition.c
@@ -1,6 +1,9 @@
+//------------------------------------------------------------------------------------------------
 [BaseContainerProps()]
 class CEN_CarrierSystem_IsCharacterCarrierCondition : SCR_AvailableActionCondition
 {
+	//------------------------------------------------------------------------------------------------
+	//! Returns true if the release action is available
 	override bool IsAvailable(SCR_AvailableActionsConditionData data)
 	{		
 		if (!data)

--- a/Scripts/Game/CEN_CarrierSystem/UserActions/CEN_CarrierSystem_CarryUserAction.c
+++ b/Scripts/Game/CEN_CarrierSystem/UserActions/CEN_CarrierSystem_CarryUserAction.c
@@ -1,5 +1,7 @@
+//------------------------------------------------------------------------------------------------
 class CEN_CarrierSystem_CarryUserAction : ScriptedUserAction
 {
+	//------------------------------------------------------------------------------------------------
 	override bool CanBeShownScript(IEntity user)
 	{
 		ChimeraCharacter ownerChar = ChimeraCharacter.Cast(GetOwner());
@@ -13,6 +15,7 @@ class CEN_CarrierSystem_CarryUserAction : ScriptedUserAction
 		return true;
 	}
 	
+	//------------------------------------------------------------------------------------------------
 	override bool CanBePerformedScript(IEntity user)
 	{
 		ChimeraCharacter userChar = ChimeraCharacter.Cast(user);
@@ -37,10 +40,13 @@ class CEN_CarrierSystem_CarryUserAction : ScriptedUserAction
 		return true;
 	}
 	
+	//------------------------------------------------------------------------------------------------
 	override void PerformAction(IEntity pOwnerEntity, IEntity pUserEntity)
 	{
 		CEN_CarrierSystem_Helper.Carry(pUserEntity, pOwnerEntity);
 	}
 	
+	//------------------------------------------------------------------------------------------------
+	//! Methods are executed on the local player
 	override bool CanBroadcastScript() { return false; };
 };

--- a/Scripts/Game/CEN_CarrierSystem/UserActions/SCR_GetInUserAction.c
+++ b/Scripts/Game/CEN_CarrierSystem/UserActions/SCR_GetInUserAction.c
@@ -1,5 +1,8 @@
+//------------------------------------------------------------------------------------------------
 modded class SCR_GetInUserAction : SCR_CompartmentUserAction
 {
+	//------------------------------------------------------------------------------------------------
+	//! Disable get in user action if player is currently carrying another
 	override bool CanBePerformedScript(IEntity user)
 	{
 		if (CEN_CarrierSystem_Helper.GetCarried(user))

--- a/Scripts/Game/CEN_CarrierSystem/UserActions/SCR_GetInUserAction.c
+++ b/Scripts/Game/CEN_CarrierSystem/UserActions/SCR_GetInUserAction.c
@@ -5,7 +5,7 @@ modded class SCR_GetInUserAction : SCR_CompartmentUserAction
 	//! Disable get in user action if player is currently carrying another
 	override bool CanBePerformedScript(IEntity user)
 	{
-		if (CEN_CarrierSystem_Helper.GetCarried(user))
+		if (CEN_CarrierSystem_Helper.IsCarrier(user))
 		{
 			SetCannotPerformReason("#CEN_CarrierSystem-UserAction_Carrying");
 			return false;


### PR DESCRIPTION
- Resolves #6
- Fixes the issue that players can enter vehicles while carrying
- Forces the carried player's replication node to update its position when release (Hopefully fixes the random issue of released players disappearing)
- Force free look for carried player
- Moves carry action to lower torso to make it consistent with the `Check injuries` action
- Improves clean-up of helper compartment entity
- Adds descriptions to methods
- Adds language config files